### PR TITLE
Fix stream URL being improperly set

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,3 @@
-#include <map>
-#include <fmt/core.h>
 #include <gst/gst.h>
 #include <gst/rtsp-server/rtsp-server.h>
 
@@ -55,7 +53,6 @@ int main(int argc, char *argv[]) {
     gst_rtsp_server_set_service(server, std::to_string(*port()).c_str());
 
     std::string pipeline;
-
     VideoSources video_type = input_type();
     switch (video_type) {
         case VideoSources::RASP:
@@ -72,10 +69,10 @@ int main(int argc, char *argv[]) {
     g_print("Starting pipeline: %s\n", pipeline.c_str());
     gst_rtsp_media_factory_set_launch(factory, pipeline.c_str());
     gst_rtsp_media_factory_set_shared(factory, true);
-    std::string m = mount();
-    const char *mount_cstr = m.c_str();
-    g_print("Mounting to %s\n", mount_cstr);
-    gst_rtsp_mount_points_add_factory(mounts, mount_cstr, factory);
+
+    std::string stream_url = mount();
+    g_print("Mounting to %s\n", stream_url.c_str());
+    gst_rtsp_mount_points_add_factory(mounts, stream_url.c_str(), factory);
     // free thing we're no longer using
     g_object_unref(mounts);
     // start rtsp server, ignoring errors
@@ -91,7 +88,7 @@ int main(int argc, char *argv[]) {
             exit(EADDRNOTAVAIL);
         }
     }
-    g_print("stream starting at rtsp://%s:%d%s\n", addr, gst_rtsp_server_get_bound_port(server), mount_cstr);
+    g_print("stream starting at rtsp://%s:%d%s\n", addr, gst_rtsp_server_get_bound_port(server), stream_url.c_str());
     {
         bool b = judgemental();
         if (b) {

--- a/src/optional.cpp
+++ b/src/optional.cpp
@@ -1,4 +1,3 @@
-#include <stdlib.h>
 #include <string>
 
 #include "optional.h"

--- a/src/optional.cpp
+++ b/src/optional.cpp
@@ -29,13 +29,12 @@ int fps = DEFAULT_FPS;
 // network
 char *addr = (char *) "0.0.0.0";
 int port_ = DEFAULT_RTSP_PORT;
-const char *url = nullptr;
+const char *url = DEFAULT_MOUNT;
 
 GOptionEntry entries[] = {
         {"rpi_cam",       'r', G_OPTION_FLAG_NONE,   G_OPTION_ARG_NONE, &rpi_cam_flag, "Use Raspberry Pi Camera module (default: false)",                                           nullptr},
         {"shared_memory", 's', G_OPTION_FLAG_NONE,   G_OPTION_ARG_NONE, &shared_mem,   "Read frames from shared memory (default: false)"},
-        {"fps",           'f', G_OPTION_FLAG_NONE,   G_OPTION_ARG_INT,  &fps,          "Framerate in FPS (default: " STRINGIFY(
-                DEFAULT_FPS) ")",                                                                                                                                                   "FPS"},
+        {"fps",           'f', G_OPTION_FLAG_NONE,   G_OPTION_ARG_INT,  &fps,          "Framerate in FPS (default: 30)",                                                            "FPS"},
         {"height",        'h', G_OPTION_FLAG_NONE,   G_OPTION_ARG_INT,  &height,       "Video height. Should be a standard resolution (in [240, 360, 480, 720] for most cameras.)", "HEIGHT"},
         {"width",         'w', G_OPTION_FLAG_NONE,   G_OPTION_ARG_INT,  &width,        "Video width. Only needs to be specified if you're using shared memory.",                    "WIDTH"},
         {"judge",         '9', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &judge,        "",                                                                                          nullptr},
@@ -44,8 +43,7 @@ GOptionEntry entries[] = {
 
 static GOptionEntry netEntries[]{
         {"address", 'a', G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING, &addr,  "Network address to bind to (default: 0.0.0.0)",       "ADDRESS"},
-        {"port",    'p', G_OPTION_FLAG_NONE, G_OPTION_ARG_INT,    &port_, "Port to listen on (default: " STRINGIFY(
-                DEFAULT_RTSP_PORT) ")",                                                                                          "PORT"},
+        {"port",    'p', G_OPTION_FLAG_NONE, G_OPTION_ARG_INT,    &port_, "Port to listen on (default: 1181)",                   "PORT"},
         {"url",     'u', G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING, &url,   "URL to stream video at (default: " DEFAULT_MOUNT ")", "URL"},
         {nullptr}
 };
@@ -121,7 +119,7 @@ std::string mount() {
             return ret;
         }
     } else {
-        return std::string(DEFAULT_MOUNT);
+        return DEFAULT_MOUNT;
     }
 }
 


### PR DESCRIPTION
Fixes #1. Yes I'm making this PR for Hacktoberfest, what are you gonna do about it?

One of these days I'm going to line up the creators of C, C++, GLib, and many other things, thank them for their invaluable contributions to computing and society on the whole, and then throw a brick at every single one of them.

Anyway, `url` being created as `nullptr` apparently caused some weird behavior on Raspbian. I'm guessing said behavior arrived as part of a libc/GLib/gcc update (who knows, not me), since we never observed this in the 2019 season proper. 